### PR TITLE
Create method for releasing and building package on CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ build:
     - cp _ci/build.gradle .
     - gradle build
   artifacts:
+    name: "gen-parser-intellij-dhall-$CI_COMMIT_SHA"
     paths:
       - gen/
 
@@ -16,3 +17,15 @@ test:
   image: hseeberger/scala-sbt:8u242_1.3.7_2.13.1
   script:
     - sbt test
+
+deploy:
+  stage: deploy
+  image: hseeberger/scala-sbt:8u242_1.3.7_2.13.1
+  script:
+    - sbt packageArtifactZip
+  artifacts:
+    name: "intellij-dhall-release-$CI_COMMIT_TAG"
+    paths:
+      - target/intellij-dhall-*.zip
+  only:
+    - tags

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,38 @@
+import ReleaseTransformations._
+
 intellijPluginName in ThisBuild := "intellij-dhall"
 intellijBuild in ThisBuild := "193.4778.7"
+
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion, // performs the initial git checks
+  tagRelease,
+  pushChanges,
+  setNextVersion,
+  commitNextVersion,
+)
+
+releaseTagComment        := s"[auto-package] Release ${(version in ThisBuild).value}"
+releaseCommitMessage     := s"[auto-package] Set release version to ${(version in ThisBuild).value}"
+releaseNextCommitMessage := s"[auto-package] Set next development version to ${(version in ThisBuild).value}"
 
 lazy val dhall = project
   .in(file("."))
   .enablePlugins(SbtIdeaPlugin)
   .settings(
     scalaVersion := "2.13.1",
-    version := "2019.3.0",
     scalaSource in Compile := baseDirectory.value / "src" / "main" / "scala",
     scalaSource in Test := baseDirectory.value / "src" / "test" / "scala",
     ideBasePackages := Seq("org.intellij.plugins.dhall"),
     unmanagedSourceDirectories in Compile += baseDirectory.value / "gen",
     resourceDirectory in Compile := baseDirectory.value / "resources",
+
+    packageMethod := PackagingMethod.Standalone(targetPath = s"lib/${name.value}-${version.value}.jar"),
+
     patchPluginXml := pluginXmlOptions { xml =>
       xml.version = version.value
     },

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,3 @@
 addSbtPlugin("org.jetbrains" % "sbt-idea-plugin" % "3.4.0")
 addSbtPlugin("org.jetbrains" % "sbt-ide-settings" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.0.0"


### PR DESCRIPTION
This introduces the sbt release command based off the sbt package. This allows a new version to be released by bumping the version, tagging, committing the change, pushing the change to master (which should trigger the Deploy stage of the CI build, which goes off only on tags), and committing a new bumped snapshot version of the change, which can be pushed to master or a branch if desired.

Once the package is built on CI, choose to download the build artifacts from the job page. This can hopefully then be uploaded to the Jetbrains Plugin Repository.