### PR TITLE
Prepare for 0.0.1 Release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,14 @@ deploy:
   stage: deploy
   image: hseeberger/scala-sbt:8u242_1.3.7_2.13.1
   script:
-    - sbt packageArtifactZip
+    # The patchPluginXML task only works on files in the SBT settings key
+    # called productDirectories.
+    # The first packageArtifact creates the files in the
+    # productDirectories path. The second packageArtifact allows the
+    # patchPluginXML task to run on the files that now exist in the
+    # productDirectories path. And the packageArtifactZip zips them
+    # into a single file.
+    - sbt packageArtifact && sbt packageArtifact && sbt packageArtifactZip
   artifacts:
     name: "intellij-dhall-release-$CI_COMMIT_TAG"
     paths:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN ["sbt", "updateIntellij"]
 COPY --from=generate /home/gradle/gen gen/
 COPY . .
 
-ENTRYPOINT ["sbt", "test"]
+ENTRYPOINT ["sbt"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
-.PHONY: test
-test:
-	docker build -t intellij-dhall-test .
-	docker run intellij-dhall-test
+include docker.Makefile
 
 .PHONY: clean-parser-gen
 clean-parser-gen:

--- a/README.md
+++ b/README.md
@@ -82,8 +82,14 @@ Resetting State
 
 The default location where `sbt` stores the downloaded development `IDEA` is `~/.intellij-dhall...`. This folder can be deleted for `sbt` to download the plugin again on its next run.
 
-To reset `sbt` caches, run `reload` or `clean` or `clearCaches` in the `sbt` shell. This may be useful after regenerating parser classes if new classes are unable to be found.
+To reset `sbt` caches, run `clean` in the `sbt` shell. This may be useful after regenerating parser classes if new classes are unable to be found.
 
 FIRST Set Conflicts
 ===
 When two FIRST sets conflict in subrules, and no backtracking is specified, we must be sure to pin the first rule that matches to agree with the expected semantics of the ABNF grammar. Three cases of this are double-quote interpolation, single-quote interpolation, and block comment nesting.
+
+
+Releasing
+===
+
+To make a new release, run `sbt release`. This will run the tests, bump the version in `version.sbt` from a snapshot to a numbered release, commit and tag the version bump, push it to the upstream (triggering a build of the artifact on Gitlab, which can be downloaded from the jobs page), and make a final commit bumping the numbered release to the next snapshot release.  

--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
 )
 
-releaseTagComment        := s"[auto-package] Release ${(version in ThisBuild).value}"
-releaseCommitMessage     := s"[auto-package] Set release version to ${(version in ThisBuild).value}"
-releaseNextCommitMessage := s"[auto-package] Set next development version to ${(version in ThisBuild).value}"
+releaseTagComment        := s"[auto-package] Release ${(ThisBuild / version).value}"
+releaseCommitMessage     := s"[auto-package] Set release version to ${(ThisBuild / version).value}"
+releaseNextCommitMessage := s"[auto-package] Set next development version to ${(ThisBuild / version).value}"
 
 lazy val dhall = project
   .in(file("."))
@@ -30,11 +30,11 @@ lazy val dhall = project
     ideBasePackages := Seq("org.intellij.plugins.dhall"),
     unmanagedSourceDirectories in Compile += baseDirectory.value / "gen",
     resourceDirectory in Compile := baseDirectory.value / "resources",
-
-    packageMethod := PackagingMethod.Standalone(targetPath = s"lib/${name.value}-${version.value}.jar"),
+    packageMethod := PackagingMethod.Standalone(targetPath = s"lib/${name.value}-${(ThisBuild / version).value}.jar"),
 
     patchPluginXml := pluginXmlOptions { xml =>
-      xml.version = version.value
+      xml.version = (ThisBuild / version).value
+      xml.sinceBuild = (ThisBuild / intellijBuild).value
     },
     intellijExternalPlugins += IntellijPlugin
       .Id("PsiViewer", Some("193-SNAPSHOT"), None),

--- a/docker.Makefile
+++ b/docker.Makefile
@@ -1,0 +1,13 @@
+CONTAINER_NAME = intellij-dhall-container
+
+.PHONY: docker-build
+docker-build:
+	docker build -t $(CONTAINER_NAME) .
+
+.PHONY: docker-test
+docker-test: docker-build
+	docker run $(CONTAINER_NAME) test
+
+.PHONY: docker-artifact
+docker-artifact: docker-build
+	docker run $(CONTAINER_NAME) packageArtifact

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,13 +1,13 @@
 <idea-plugin>
     <id>org.intellij.plugins.dhall</id>
     <name>Dhall</name>
-    <version>0.1</version>
+    <version>0</version>
     <vendor email="garethwtan@gmail.com" url="https://github.com/garetht">Gareth T</vendor>
 
-    <description>Provides Dhall language support. https://dhall-lang.org/</description>
+    <description>Provides basic Dhall language support. https://dhall-lang.org/</description>
 
     <change-notes>
-        This plugin continues to be under development.
+        This initial release adds syntax highlighting and custom selection support.
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.0"
+version in ThisBuild := "0.0.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.1-SNAPSHOT"
+version in ThisBuild := "0.0.1"


### PR DESCRIPTION
A tricky thing about using the SBT IDEA plugin to patch xml is that it only works on p product files within the SBT settings key productDirectories. To correctly patch the XML,  we use packageArtifact to generate the files into the productDirectory. Then, we run it again to patch the productDirectory XML. Finally, we run packageArtifactZip to zip all the fgenerated files into a ZIP for uploading to the plugin repository. We also add several Dockerfile commands and slightly generalize the Dockerfile so that its entrypoint is just sbt and not specifically sbt test