### PR TITLE
Color Settings Page Improvements

### DIFF
--- a/src/main/scala/org/intellij/plugins/dhall/DhallColorSettingsPage.scala
+++ b/src/main/scala/org/intellij/plugins/dhall/DhallColorSettingsPage.scala
@@ -40,6 +40,10 @@ object DhallColorSettingsPage {
       DhallSyntaxHighlighter.RECORD_TYPE_KEY
     ),
     new AttributesDescriptor(
+      "Union Type Data Constructor",
+      DhallSyntaxHighlighter.UNION_TYPE_DATA_CONSTRUCTOR
+    ),
+    new AttributesDescriptor(
       "Block Comment",
       DefaultLanguageHighlighterColors.BLOCK_COMMENT
     ),
@@ -61,6 +65,26 @@ object DhallColorSettingsPage {
       "Interpolation",
       DefaultLanguageHighlighterColors.TEMPLATE_LANGUAGE_COLOR
     ),
+    new AttributesDescriptor(
+      "Keyword",
+      DefaultLanguageHighlighterColors.KEYWORD
+    ),
+    new AttributesDescriptor(
+      "Builtin",
+      DefaultLanguageHighlighterColors.PREDEFINED_SYMBOL
+    ),
+    new AttributesDescriptor(
+      "Dot Access",
+      DefaultLanguageHighlighterColors.DOT
+    ),
+    new AttributesDescriptor(
+      "Identifier",
+      DefaultLanguageHighlighterColors.IDENTIFIER
+    ),
+    new AttributesDescriptor(
+      "Lambda Parameter",
+      DefaultLanguageHighlighterColors.PARAMETER
+    )
   )
 }
 
@@ -107,7 +131,7 @@ class DhallColorSettingsPage extends ColorSettingsPage {
       "path" -> DhallSyntaxHighlighter.PATH,
       "env-import" -> DhallSyntaxHighlighter.ENVIRONMENT_IMPORT,
       "env-import-name" -> DhallSyntaxHighlighter.ENVIRONMENT_IMPORT_NAME,
-      "union-type" -> DhallSyntaxHighlighter.UNION_TYPE_ENTRY,
+      "union-type" -> DhallSyntaxHighlighter.UNION_TYPE_DATA_CONSTRUCTOR,
       "ip-literal" -> DhallSyntaxHighlighter.IP_LITERAL,
       "dot" -> DefaultLanguageHighlighterColors.DOT,
       "lambda" -> DefaultLanguageHighlighterColors.FUNCTION_DECLARATION,

--- a/src/main/scala/org/intellij/plugins/dhall/DhallSyntaxHighlighter.scala
+++ b/src/main/scala/org/intellij/plugins/dhall/DhallSyntaxHighlighter.scala
@@ -22,7 +22,7 @@ object DhallSyntaxHighlighter {
       "ENVIRONMENT_IMPORT_NAME",
       DefaultLanguageHighlighterColors.IDENTIFIER
     )
-  val UNION_TYPE_ENTRY: TextAttributesKey = createTextAttributesKey(
+  val UNION_TYPE_DATA_CONSTRUCTOR: TextAttributesKey = createTextAttributesKey(
     "UNION_TYPE_ENTRY",
     DefaultLanguageHighlighterColors.CLASS_NAME
   )

--- a/src/main/scala/org/intellij/plugins/dhall/annotator/SyntaxInfoAnnotator.scala
+++ b/src/main/scala/org/intellij/plugins/dhall/annotator/SyntaxInfoAnnotator.scala
@@ -107,7 +107,7 @@ object SyntaxInfoAnnotator {
           Some(DefaultLanguageHighlighterColors.TEMPLATE_LANGUAGE_COLOR)
         )
       case _: DhallUnionTypeEntry =>
-        (defaultTextRange, Some(DhallSyntaxHighlighter.UNION_TYPE_ENTRY))
+        (defaultTextRange, Some(DhallSyntaxHighlighter.UNION_TYPE_DATA_CONSTRUCTOR))
       case lb: DhallLetBinding =>
         (
           this.textRange(lb.getNonreservedLabel),

--- a/src/test/scala/org/intellij/plugins/dhall/ColorSettingsPageTest.scala
+++ b/src/test/scala/org/intellij/plugins/dhall/ColorSettingsPageTest.scala
@@ -1,0 +1,51 @@
+package org.intellij.plugins.dhall
+
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import junit.framework.TestCase
+import org.junit.Assert._
+
+import scala.jdk.CollectionConverters.MapHasAsScala
+
+class ColorSettingsPageTest extends TestCase {
+  def testAllExampleHighlightsCanBeEdited(): Unit = {
+    val colorSettingsPage = new DhallColorSettingsPage()
+    val exampleHighlights =
+      colorSettingsPage.getAdditionalHighlightingTagToDescriptorMap.asScala.valuesIterator.toSet
+    val editableHighlights =
+      colorSettingsPage.getAttributeDescriptors.toList.map(_.getKey).toSet
+
+    assertEquals(
+      "There were text attributes in the example text but are which are not editable in the settings page.",
+      exampleHighlights.diff(editableHighlights),
+      Set(),
+    )
+    assertEquals(
+      "There were text attributes editable in the settings page but which are not in the example text",
+      editableHighlights.diff(exampleHighlights),
+      Set(),
+    )
+  }
+
+  def testAllCustomDhallSyntaxHighlightsAreEditable(): Unit = {
+    val customDhallSyntaxHighlights =
+      DhallSyntaxHighlighter.getClass.getDeclaredMethods
+        .collect(f => {
+          // N.B. If we convert this to an if we lose the
+          // type inference that we get from a PartialFunction
+          f.getReturnType == classOf[TextAttributesKey] match {
+            case true =>
+              f.invoke(DhallSyntaxHighlighter).asInstanceOf[TextAttributesKey]
+          }
+        })
+        .toSet
+    val colorSettingsPage = new DhallColorSettingsPage()
+    val editableHighlights =
+      colorSettingsPage.getAttributeDescriptors.toList.map(_.getKey).toSet
+
+    assertEquals(
+      "There were custom Dhall syntax highlighting keys that were not editable in the color settings page.",
+      customDhallSyntaxHighlights.diff(editableHighlights),
+      Set(),
+    )
+  }
+}

--- a/src/test/scala/org/intellij/plugins/dhall/annotator/SyntaxHighlightAnnotatorTest.scala
+++ b/src/test/scala/org/intellij/plugins/dhall/annotator/SyntaxHighlightAnnotatorTest.scala
@@ -90,9 +90,9 @@ class SyntaxHighlightAnnotatorTest
     this.assertHighlight(
       "<Hello|World|There>",
       List(
-        HighlightAssert(text = "Hello", key = D.UNION_TYPE_ENTRY),
-        HighlightAssert(text = "World", key = D.UNION_TYPE_ENTRY),
-        HighlightAssert(text = "There", key = D.UNION_TYPE_ENTRY),
+        HighlightAssert(text = "Hello", key = D.UNION_TYPE_DATA_CONSTRUCTOR),
+        HighlightAssert(text = "World", key = D.UNION_TYPE_DATA_CONSTRUCTOR),
+        HighlightAssert(text = "There", key = D.UNION_TYPE_DATA_CONSTRUCTOR),
       )
     )
   }


### PR DESCRIPTION
Several tests are added to ensure that all text attribute keys that appear in the tags used in the example text are editable on the text settings page, and that all custom  Dhall syntax highlight attribute keys are in the tags available to the example text. For now, we presume that the example text uses all XML tags available to it, but may test for this in the future.

Closes #13 and #14